### PR TITLE
title shows when poster is expanded

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -207,3 +207,9 @@ p.description.ng-binding {
   position: absolute;
   color: ivory;
 }
+
+h1.title.ng-binding {
+  width: 300px;
+    position: relative;
+    color: ivory;
+}


### PR DESCRIPTION
Added an enlarged title which displays when poster is expanded. Added a bit of relevant css. NOTE: Do not change the position attributes as they are required to be what they currently are for these to display correctly.